### PR TITLE
Implement product and category modules

### DIFF
--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -1,3 +1,99 @@
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
 from .. import models, schemas
-from .common import get_crud_router
-router = get_crud_router(models.Category, schemas.CategoryRead, schemas.CategoryCreate, "/categories")
+from ..services import category_service
+from ..database import get_db
+from ..auth import get_current_user
+from ..dependencies import get_current_org
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+
+def _ensure_admin(db: Session, user: models.User, org: models.Organization):
+    membership = (
+        db.query(models.UserOrganization)
+        .filter_by(user_id=user.id, org_id=org.id)
+        .first()
+    )
+    if not membership or membership.role.lower() != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+
+@router.get("/", response_model=List[schemas.CategoryRead])
+def list_categories(
+    search: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    categories = category_service.list_categories(
+        db, current_user, search=search, skip=skip, limit=limit
+    )
+    return categories
+
+
+@router.post("/", response_model=schemas.CategoryRead)
+def create_category(
+    category_in: schemas.CategoryCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    return category_service.create_category(db, category_in, current_user)
+
+
+@router.get("/{category_id}", response_model=schemas.CategoryRead)
+def get_category(
+    category_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    category = category_service.get_category(db, category_id, current_user)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    return category
+
+
+@router.put("/{category_id}", response_model=schemas.CategoryRead)
+def update_category(
+    category_id: UUID,
+    category_in: schemas.CategoryCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    category = category_service.update_category(db, category_id, category_in, current_user)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    return category
+
+
+@router.delete("/{category_id}")
+def delete_category(
+    category_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    success = category_service.delete_category(db, category_id, current_user)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    return {"ok": True}

--- a/backend/app/routers/products.py
+++ b/backend/app/routers/products.py
@@ -1,3 +1,105 @@
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
 from .. import models, schemas
-from .common import get_crud_router
-router = get_crud_router(models.Product, schemas.ProductRead, schemas.ProductCreate, "/products")
+from ..services import product_service
+from ..database import get_db
+from ..auth import get_current_user
+from ..dependencies import get_current_org
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+def _ensure_admin(db: Session, user: models.User, org: models.Organization):
+    membership = (
+        db.query(models.UserOrganization)
+        .filter_by(user_id=user.id, org_id=org.id)
+        .first()
+    )
+    if not membership or membership.role.lower() != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+
+@router.get("/", response_model=List[schemas.ProductRead])
+def list_products(
+    category_id: Optional[UUID] = None,
+    search: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    products = product_service.list_products(
+        db,
+        current_user,
+        category_id=category_id,
+        search=search,
+        skip=skip,
+        limit=limit,
+    )
+    return products
+
+
+@router.post("/", response_model=schemas.ProductRead)
+def create_product(
+    product_in: schemas.ProductCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    return product_service.create_product(db, product_in, current_user)
+
+
+@router.get("/{product_id}", response_model=schemas.ProductRead)
+def get_product(
+    product_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    product = product_service.get_product(db, product_id, current_user)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+@router.put("/{product_id}", response_model=schemas.ProductRead)
+def update_product(
+    product_id: UUID,
+    product_in: schemas.ProductCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    product = product_service.update_product(db, product_id, product_in, current_user)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+@router.delete("/{product_id}")
+def delete_product(
+    product_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    success = product_service.delete_product(db, product_id, current_user)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return {"ok": True}

--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -1,0 +1,72 @@
+from typing import List, Optional
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+from sqlalchemy import or_
+
+from .. import models, schemas
+
+
+def create_category(db: Session, category_in: schemas.CategoryCreate, current_user: models.User):
+    """Create a new category for the current user's organization."""
+    category = models.Category(**category_in.dict(), organization_id=current_user.organization_id)
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+def get_category(db: Session, category_id: UUID, current_user: models.User):
+    """Return a single category belonging to the current user's organization."""
+    return (
+        db.query(models.Category)
+        .filter(
+            models.Category.id == category_id,
+            models.Category.organization_id == current_user.organization_id,
+        )
+        .first()
+    )
+
+
+def list_categories(
+    db: Session,
+    current_user: models.User,
+    search: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> List[models.Category]:
+    """List categories for the current user's organization with optional search."""
+    query = db.query(models.Category).filter(
+        models.Category.organization_id == current_user.organization_id
+    )
+    if search:
+        like = f"%{search}%"
+        query = query.filter(
+            or_(models.Category.name.ilike(like), models.Category.code.ilike(like))
+        )
+    return query.offset(skip).limit(limit).all()
+
+
+def update_category(
+    db: Session, category_id: UUID, category_in: schemas.CategoryCreate, current_user: models.User
+):
+    """Update an existing category in the current user's organization."""
+    category = get_category(db, category_id, current_user)
+    if not category:
+        return None
+    for field, value in category_in.dict().items():
+        setattr(category, field, value)
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+def delete_category(db: Session, category_id: UUID, current_user: models.User) -> bool:
+    """Delete a category from the current user's organization."""
+    category = get_category(db, category_id, current_user)
+    if not category:
+        return False
+    db.delete(category)
+    db.commit()
+    return True

--- a/backend/app/services/product_service.py
+++ b/backend/app/services/product_service.py
@@ -1,0 +1,74 @@
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+from sqlalchemy import or_
+
+from .. import models, schemas
+
+
+def create_product(db: Session, product_in: schemas.ProductCreate, current_user: models.User):
+    """Create a new product for the current user's organization."""
+    product = models.Product(**product_in.dict(), organization_id=current_user.organization_id)
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def get_product(db: Session, product_id: UUID, current_user: models.User):
+    """Return a single product belonging to the current user's organization."""
+    return (
+        db.query(models.Product)
+        .filter(
+            models.Product.id == product_id,
+            models.Product.organization_id == current_user.organization_id,
+        )
+        .first()
+    )
+
+
+def list_products(
+    db: Session,
+    current_user: models.User,
+    category_id: Optional[UUID] = None,
+    search: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> List[models.Product]:
+    """List products for the current user's organization with optional filters."""
+    query = db.query(models.Product).filter(
+        models.Product.organization_id == current_user.organization_id
+    )
+    if category_id:
+        query = query.filter(models.Product.category_id == category_id)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(
+            or_(models.Product.name.ilike(like), models.Product.sku.ilike(like))
+        )
+    return query.offset(skip).limit(limit).all()
+
+
+def update_product(
+    db: Session, product_id: UUID, product_in: schemas.ProductCreate, current_user: models.User
+):
+    """Update an existing product in the current user's organization."""
+    product = get_product(db, product_id, current_user)
+    if not product:
+        return None
+    for field, value in product_in.dict().items():
+        setattr(product, field, value)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def delete_product(db: Session, product_id: UUID, current_user: models.User) -> bool:
+    """Delete a product from the current user's organization."""
+    product = get_product(db, product_id, current_user)
+    if not product:
+        return False
+    db.delete(product)
+    db.commit()
+    return True

--- a/frontend/components/CategoryForm.tsx
+++ b/frontend/components/CategoryForm.tsx
@@ -1,0 +1,45 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const categorySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  code: z.string().min(1, 'Code is required'),
+});
+
+export type CategoryFormValues = z.infer<typeof categorySchema>;
+
+interface CategoryFormProps {
+  initialValues?: CategoryFormValues;
+  onSubmit: (data: CategoryFormValues) => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export default function CategoryForm({ initialValues, onSubmit, onCancel }: CategoryFormProps) {
+  const { register, handleSubmit, formState: { errors } } = useForm<CategoryFormValues>({
+    resolver: zodResolver(categorySchema),
+    defaultValues: initialValues || {},
+  });
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white p-6 rounded w-96 space-y-4">
+        <h2 className="text-lg font-bold">Category</h2>
+        <div>
+          <label className="block">Name</label>
+          <input className="border p-2 w-full" {...register('name')} />
+          {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+        </div>
+        <div>
+          <label className="block">Code</label>
+          <input className="border p-2 w-full" {...register('code')} />
+          {errors.code && <p className="text-red-500 text-sm">{errors.code.message}</p>}
+        </div>
+        <div className="flex justify-end space-x-2">
+          <button type="button" onClick={onCancel} className="px-4 py-2 bg-gray-300">Cancel</button>
+          <button type="submit" className="px-4 py-2 bg-blue-500 text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -8,6 +8,8 @@ export default function Layout({ children }: { children: ReactNode }) {
         <nav className="flex flex-col space-y-2">
           <Link href="/">Dashboard</Link>
           <Link href="/partners">Partners</Link>
+          <Link href="/products">Products</Link>
+          <Link href="/categories">Categories</Link>
         </nav>
       </aside>
       <div className="flex-1">

--- a/frontend/components/ProductForm.tsx
+++ b/frontend/components/ProductForm.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { listCategories, Category } from '../lib/api/categories';
+
+const productSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  sku: z.string().min(1, 'SKU is required'),
+  category_id: z.string().uuid().optional().or(z.literal('')),
+  base_price_sqm: z.coerce.number().optional(),
+});
+
+export type ProductFormValues = z.infer<typeof productSchema>;
+
+interface ProductFormProps {
+  initialValues?: ProductFormValues;
+  onSubmit: (data: ProductFormValues) => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export default function ProductForm({ initialValues, onSubmit, onCancel }: ProductFormProps) {
+  const { register, handleSubmit, formState: { errors } } = useForm<ProductFormValues>({
+    resolver: zodResolver(productSchema),
+    defaultValues: initialValues || {},
+  });
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const token = '';
+  const org = '';
+
+  useEffect(() => {
+    async function loadCategories() {
+      const data = await listCategories(token, org);
+      setCategories(data);
+    }
+    loadCategories();
+  }, []);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white p-6 rounded w-96 space-y-4">
+        <h2 className="text-lg font-bold">Product</h2>
+        <div>
+          <label className="block">Name</label>
+          <input className="border p-2 w-full" {...register('name')} />
+          {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+        </div>
+        <div>
+          <label className="block">SKU</label>
+          <input className="border p-2 w-full" {...register('sku')} />
+          {errors.sku && <p className="text-red-500 text-sm">{errors.sku.message}</p>}
+        </div>
+        <div>
+          <label className="block">Category</label>
+          <select className="border p-2 w-full" {...register('category_id')}>
+            <option value="">Select</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block">Base Price (m²)</label>
+          <input type="number" step="0.01" className="border p-2 w-full" {...register('base_price_sqm')} />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <button type="button" onClick={onCancel} className="px-4 py-2 bg-gray-300">Cancel</button>
+          <button type="submit" className="px-4 py-2 bg-blue-500 text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/lib/api/categories.ts
+++ b/frontend/lib/api/categories.ts
@@ -1,0 +1,70 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+});
+
+export interface Category {
+  id: string;
+  name: string;
+  code: string;
+}
+
+export interface CategoryInput {
+  name: string;
+  code: string;
+}
+
+export async function listCategories(
+  token: string,
+  org: string,
+  params: { search?: string; skip?: number; limit?: number } = {}
+) {
+  const res = await api.get<Category[]>(`/categories`, {
+    params,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function createCategory(token: string, org: string, data: CategoryInput) {
+  const res = await api.post<Category>(`/categories`, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function getCategory(token: string, org: string, id: string) {
+  const res = await api.get<Category>(`/categories/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function updateCategory(token: string, org: string, id: string, data: CategoryInput) {
+  const res = await api.put<Category>(`/categories/${id}`, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function deleteCategory(token: string, org: string, id: string) {
+  await api.delete(`/categories/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+}

--- a/frontend/lib/api/products.ts
+++ b/frontend/lib/api/products.ts
@@ -1,0 +1,74 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+});
+
+export interface Product {
+  id: string;
+  name: string;
+  sku: string;
+  category_id?: string;
+  base_price_sqm?: number;
+}
+
+export interface ProductInput {
+  name: string;
+  sku: string;
+  category_id?: string;
+  base_price_sqm?: number;
+}
+
+export async function listProducts(
+  token: string,
+  org: string,
+  params: { search?: string; category_id?: string; skip?: number; limit?: number } = {}
+) {
+  const res = await api.get<Product[]>(`/products`, {
+    params,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function createProduct(token: string, org: string, data: ProductInput) {
+  const res = await api.post<Product>(`/products`, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function getProduct(token: string, org: string, id: string) {
+  const res = await api.get<Product>(`/products/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function updateProduct(token: string, org: string, id: string, data: ProductInput) {
+  const res = await api.put<Product>(`/products/${id}`, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function deleteProduct(token: string, org: string, id: string) {
+  await api.delete(`/products/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+}

--- a/frontend/pages/categories/index.tsx
+++ b/frontend/pages/categories/index.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import CategoryForm, { CategoryFormValues } from '../../components/CategoryForm';
+import {
+  listCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  Category,
+} from '../../lib/api/categories';
+
+export default function CategoriesPage() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [search, setSearch] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+
+  const token = '';
+  const org = '';
+
+  const loadCategories = async () => {
+    const params: any = {};
+    if (search) params.search = search;
+    const data = await listCategories(token, org, params);
+    setCategories(data);
+  };
+
+  useEffect(() => {
+    loadCategories();
+  }, [search]);
+
+  const handleCreate = () => {
+    setEditingCategory(null);
+    setModalOpen(true);
+  };
+
+  const handleSubmit = async (values: CategoryFormValues) => {
+    if (editingCategory) {
+      await updateCategory(token, org, editingCategory.id, values);
+    } else {
+      await createCategory(token, org, values);
+    }
+    setModalOpen(false);
+    await loadCategories();
+  };
+
+  const handleEdit = (category: Category) => {
+    setEditingCategory(category);
+    setModalOpen(true);
+  };
+
+  const handleDelete = async (category: Category) => {
+    if (confirm('Delete category?')) {
+      await deleteCategory(token, org, category.id);
+      await loadCategories();
+    }
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-xl font-bold mb-4">Kategoriler</h1>
+      <div className="mb-4 flex space-x-2">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Ara"
+          className="border p-2"
+        />
+        <button
+          onClick={handleCreate}
+          className="ml-auto bg-blue-500 text-white px-4 py-2"
+        >
+          Yeni Kategori Ekle
+        </button>
+      </div>
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr>
+            <th className="border p-2 text-left">Name</th>
+            <th className="border p-2 text-left">Code</th>
+            <th className="border p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {categories.map((c) => (
+            <tr key={c.id}>
+              <td className="border p-2">{c.name}</td>
+              <td className="border p-2">{c.code}</td>
+              <td className="border p-2 space-x-2 text-center">
+                <button
+                  onClick={() => handleEdit(c)}
+                  className="px-2 py-1 bg-yellow-400"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => handleDelete(c)}
+                  className="px-2 py-1 bg-red-500 text-white"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {modalOpen && (
+        <CategoryForm
+          initialValues={editingCategory || undefined}
+          onSubmit={handleSubmit}
+          onCancel={() => setModalOpen(false)}
+        />
+      )}
+    </Layout>
+  );
+}

--- a/frontend/pages/products/index.tsx
+++ b/frontend/pages/products/index.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import ProductForm, { ProductFormValues } from '../../components/ProductForm';
+import {
+  listProducts,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+  Product,
+} from '../../lib/api/products';
+import { listCategories, Category } from '../../lib/api/categories';
+
+export default function ProductsPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('All');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingProduct, setEditingProduct] = useState<Product | null>(null);
+
+  const token = '';
+  const org = '';
+
+  const loadCategories = async () => {
+    const data = await listCategories(token, org);
+    setCategories(data);
+  };
+
+  const loadProducts = async () => {
+    const params: any = {};
+    if (search) params.search = search;
+    if (categoryFilter !== 'All') params.category_id = categoryFilter;
+    const data = await listProducts(token, org, params);
+    setProducts(data);
+  };
+
+  useEffect(() => {
+    loadCategories();
+  }, []);
+
+  useEffect(() => {
+    loadProducts();
+  }, [search, categoryFilter]);
+
+  const handleCreate = () => {
+    setEditingProduct(null);
+    setModalOpen(true);
+  };
+
+  const handleSubmit = async (values: ProductFormValues) => {
+    if (editingProduct) {
+      await updateProduct(token, org, editingProduct.id, values);
+    } else {
+      await createProduct(token, org, values);
+    }
+    setModalOpen(false);
+    await loadProducts();
+  };
+
+  const handleEdit = (product: Product) => {
+    setEditingProduct(product);
+    setModalOpen(true);
+  };
+
+  const handleDelete = async (product: Product) => {
+    if (confirm('Delete product?')) {
+      await deleteProduct(token, org, product.id);
+      await loadProducts();
+    }
+  };
+
+  const getCategoryName = (id?: string) =>
+    categories.find((c) => c.id === id)?.name || '';
+
+  return (
+    <Layout>
+      <h1 className="text-xl font-bold mb-4">Ürünler</h1>
+      <div className="mb-4 flex space-x-2">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Ara"
+          className="border p-2"
+        />
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          className="border p-2"
+        >
+          <option value="All">All</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={handleCreate}
+          className="ml-auto bg-blue-500 text-white px-4 py-2"
+        >
+          Yeni Ürün Ekle
+        </button>
+      </div>
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr>
+            <th className="border p-2 text-left">Name</th>
+            <th className="border p-2 text-left">SKU</th>
+            <th className="border p-2 text-left">Category</th>
+            <th className="border p-2 text-left">Base Price (m²)</th>
+            <th className="border p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {products.map((p) => (
+            <tr key={p.id}>
+              <td className="border p-2">{p.name}</td>
+              <td className="border p-2">{p.sku}</td>
+              <td className="border p-2">{getCategoryName(p.category_id)}</td>
+              <td className="border p-2">{p.base_price_sqm}</td>
+              <td className="border p-2 space-x-2 text-center">
+                <button
+                  onClick={() => handleEdit(p)}
+                  className="px-2 py-1 bg-yellow-400"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => handleDelete(p)}
+                  className="px-2 py-1 bg-red-500 text-white"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {modalOpen && (
+        <ProductForm
+          initialValues={editingProduct || undefined}
+          onSubmit={handleSubmit}
+          onCancel={() => setModalOpen(false)}
+        />
+      )}
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- implement full CRUD services and routers for products and categories with org scoping
- add frontend product and category management pages with forms and API clients
- update layout navigation

## Testing
- `pytest`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb5a74f08832dae66607c9d17b880