### PR TITLE
Implement order module with backend service and frontend pages

### DIFF
--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -1,3 +1,96 @@
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
 from .. import models, schemas
-from .common import get_crud_router
-router = get_crud_router(models.Order, schemas.OrderRead, schemas.OrderCreate, "/orders")
+from ..services import order_service
+from ..database import get_db
+from ..auth import get_current_user
+from ..dependencies import get_current_org
+
+router = APIRouter(prefix="/orders", tags=["orders"])
+
+
+def _ensure_admin(db: Session, user: models.User, org: models.Organization):
+    membership = (
+        db.query(models.UserOrganization)
+        .filter_by(user_id=user.id, org_id=org.id)
+        .first()
+    )
+    if not membership or membership.role.lower() != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+
+class StatusUpdate(BaseModel):
+    status: str
+
+
+@router.post("/", response_model=schemas.OrderDetail)
+def create_order(
+    order_in: schemas.OrderCreateWithItems,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    order = order_service.create_order(db, order_in, current_user)
+    order_db, items = order_service.get_order(db, order.id, current_user)
+    if not order_db:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    return schemas.OrderDetail(
+        **schemas.OrderRead.from_orm(order_db).dict(),
+        items=[schemas.OrderItemRead.from_orm(i) for i in items],
+    )
+
+
+@router.get("/", response_model=List[schemas.OrderRead])
+def list_orders(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    orders = order_service.list_orders(db, current_user, skip, limit)
+    return orders
+
+
+@router.get("/{order_id}", response_model=schemas.OrderDetail)
+def get_order(
+    order_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    order, items = order_service.get_order(db, order_id, current_user)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
+    return schemas.OrderDetail(
+        **schemas.OrderRead.from_orm(order).dict(),
+        items=[schemas.OrderItemRead.from_orm(i) for i in items],
+    )
+
+
+@router.post("/{order_id}/status", response_model=schemas.OrderRead)
+def change_status(
+    order_id: UUID,
+    status_in: StatusUpdate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    org: models.Organization = Depends(get_current_org),
+):
+    current_user.organization_id = org.id
+    _ensure_admin(db, current_user, org)
+    order = order_service.update_order_status(db, order_id, status_in.status, current_user)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
+    return order

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, List
 from uuid import UUID
 from pydantic import BaseModel, EmailStr
 from enum import Enum
@@ -149,6 +149,24 @@ class OrderItemRead(OrderItemBase):
 
     class Config:
         orm_mode = True
+
+
+class OrderItemNested(BaseModel):
+    product_id: Optional[UUID]
+    description: Optional[str]
+    width: Optional[int]
+    height: Optional[int]
+    quantity: Optional[int]
+    unit_price: Optional[Decimal]
+    notes: Optional[str]
+
+
+class OrderCreateWithItems(OrderBase):
+    items: List[OrderItemNested] = []
+
+
+class OrderDetail(OrderRead):
+    items: List[OrderItemRead] = []
 
 class PurchaseOrderBase(BaseModel):
     partner_id: Optional[UUID]

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -1,0 +1,160 @@
+from datetime import date
+from decimal import Decimal
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def _generate_order_number(db: Session, org_id: UUID, order_date: date) -> str:
+    """Generate sequential order number like '2025-001' per organization per year."""
+    year = order_date.year
+    prefix = f"{year}-"
+    last_order = (
+        db.query(models.Order)
+        .filter(
+            models.Order.organization_id == org_id,
+            models.Order.order_number.like(f"{prefix}%"),
+        )
+        .order_by(models.Order.order_number.desc())
+        .first()
+    )
+    seq = 1
+    if last_order and last_order.order_number:
+        try:
+            seq = int(last_order.order_number.split("-")[1]) + 1
+        except Exception:
+            seq = 1
+    return f"{year}-{seq:03d}"
+
+
+def create_order(
+    db: Session, order_in: schemas.OrderCreateWithItems, current_user: models.User
+) -> models.Order:
+    """Create an order with items for the current organization."""
+    ord_date = order_in.order_date or date.today()
+    order_number = _generate_order_number(db, current_user.organization_id, ord_date)
+
+    order = models.Order(
+        organization_id=current_user.organization_id,
+        partner_id=order_in.partner_id,
+        project_name=order_in.project_name,
+        order_number=order_number,
+        status=order_in.status or "DRAFT",
+        order_date=ord_date,
+        delivery_date=order_in.delivery_date,
+        delivery_method=order_in.delivery_method,
+        notes=order_in.notes,
+        grand_total=Decimal("0"),
+    )
+    db.add(order)
+    db.flush()  # obtain order.id
+
+    grand_total = Decimal("0")
+    for item_in in order_in.items:
+        width_m = Decimal(item_in.width or 0) / Decimal(1000)
+        height_m = Decimal(item_in.height or 0) / Decimal(1000)
+        quantity = item_in.quantity or 0
+        unit_price = Decimal(item_in.unit_price or 0)
+        total_price = width_m * height_m * quantity * unit_price
+        grand_total += total_price
+
+        order_item = models.OrderItem(
+            organization_id=current_user.organization_id,
+            order_id=order.id,
+            product_id=item_in.product_id,
+            description=item_in.description,
+            width=item_in.width,
+            height=item_in.height,
+            quantity=quantity,
+            unit_price=unit_price,
+            total_price=total_price,
+            notes=item_in.notes,
+        )
+        db.add(order_item)
+
+    order.grand_total = grand_total
+    db.commit()
+    db.refresh(order)
+    return order
+
+
+def update_order_status(
+    db: Session, order_id: UUID, status: str, current_user: models.User
+) -> Optional[models.Order]:
+    order = (
+        db.query(models.Order)
+        .filter(
+            models.Order.id == order_id,
+            models.Order.organization_id == current_user.organization_id,
+        )
+        .first()
+    )
+    if not order:
+        return None
+
+    order.status = status
+    db.add(order)
+
+    if status == "URETIMDE":
+        items = (
+            db.query(models.OrderItem)
+            .filter(
+                models.OrderItem.order_id == order.id,
+                models.OrderItem.organization_id == current_user.organization_id,
+            )
+            .all()
+        )
+        for idx, item in enumerate(items, start=1):
+            job = models.ProductionJob(
+                organization_id=current_user.organization_id,
+                order_item_id=item.id,
+                job_number=f"{order.order_number}-{idx:03d}",
+                status="PENDING",
+                quantity_required=item.quantity,
+                quantity_produced=0,
+            )
+            db.add(job)
+
+    db.commit()
+    db.refresh(order)
+    return order
+
+
+def list_orders(
+    db: Session, current_user: models.User, skip: int = 0, limit: int = 100
+) -> List[models.Order]:
+    return (
+        db.query(models.Order)
+        .filter(models.Order.organization_id == current_user.organization_id)
+        .order_by(models.Order.order_date.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def get_order(
+    db: Session, order_id: UUID, current_user: models.User
+) -> Tuple[Optional[models.Order], List[models.OrderItem]]:
+    order = (
+        db.query(models.Order)
+        .filter(
+            models.Order.id == order_id,
+            models.Order.organization_id == current_user.organization_id,
+        )
+        .first()
+    )
+    if not order:
+        return None, []
+    items = (
+        db.query(models.OrderItem)
+        .filter(
+            models.OrderItem.order_id == order.id,
+            models.OrderItem.organization_id == current_user.organization_id,
+        )
+        .all()
+    )
+    return order, items

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -10,6 +10,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/partners">Partners</Link>
           <Link href="/products">Products</Link>
           <Link href="/categories">Categories</Link>
+          <Link href="/orders">Siparişler</Link>
         </nav>
       </aside>
       <div className="flex-1">

--- a/frontend/lib/api/orders.ts
+++ b/frontend/lib/api/orders.ts
@@ -1,0 +1,96 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+});
+
+export interface Order {
+  id: string;
+  partner_id?: string;
+  project_name?: string;
+  order_number?: string;
+  status?: string;
+  order_date?: string;
+  delivery_date?: string;
+  delivery_method?: string;
+  notes?: string;
+  grand_total?: number;
+}
+
+export interface OrderItem {
+  id: string;
+  order_id: string;
+  product_id?: string;
+  description?: string;
+  width?: number;
+  height?: number;
+  quantity?: number;
+  unit_price?: number;
+  total_price?: number;
+  notes?: string;
+}
+
+export interface OrderItemInput {
+  product_id?: string;
+  description?: string;
+  width?: number;
+  height?: number;
+  quantity?: number;
+  unit_price?: number;
+  notes?: string;
+}
+
+export interface OrderInput {
+  partner_id?: string;
+  project_name?: string;
+  status?: string;
+  order_date?: string;
+  delivery_date?: string;
+  delivery_method?: string;
+  notes?: string;
+  items: OrderItemInput[];
+}
+
+export interface OrderDetail extends Order {
+  items: OrderItem[];
+}
+
+export async function createOrder(token: string, org: string, data: OrderInput) {
+  const res = await api.post<OrderDetail>(`/orders`, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function listOrders(token: string, org: string) {
+  const res = await api.get<Order[]>(`/orders`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function getOrder(token: string, org: string, id: string) {
+  const res = await api.get<OrderDetail>(`/orders/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function updateOrderStatus(token: string, org: string, id: string, status: string) {
+  const res = await api.post<Order>(`/orders/${id}/status`, { status }, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}

--- a/frontend/pages/orders/[id].tsx
+++ b/frontend/pages/orders/[id].tsx
@@ -1,0 +1,84 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { getOrder, updateOrderStatus, OrderDetail } from '../../lib/api/orders';
+
+export default function OrderDetailPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [order, setOrder] = useState<OrderDetail | null>(null);
+  const [status, setStatus] = useState('');
+  const token = '';
+  const org = '';
+
+  useEffect(() => {
+    if (id) {
+      getOrder(token, org, id as string).then((data) => {
+        setOrder(data);
+        setStatus(data.status || '');
+      });
+    }
+  }, [id]);
+
+  const handleStatus = async () => {
+    if (!id) return;
+    await updateOrderStatus(token, org, id as string, status);
+    setOrder(order ? { ...order, status } : order);
+  };
+
+  return (
+    <Layout>
+      {order ? (
+        <div className="space-y-4">
+          <h1 className="text-xl font-bold">Sipariş {order.order_number}</h1>
+          <div>Durum: {order.status}</div>
+          <div className="flex items-center space-x-2">
+            <select
+              className="border p-1"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              {['DRAFT', 'SIPARIS', 'URETIMDE', 'TAMAMLANDI'].map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+            <button
+              className="bg-blue-500 text-white px-4 py-2"
+              onClick={handleStatus}
+            >
+              Durumu Güncelle
+            </button>
+          </div>
+          <table className="min-w-full bg-white">
+            <thead>
+              <tr>
+                <th className="border p-2">Ürün</th>
+                <th className="border p-2">En</th>
+                <th className="border p-2">Boy</th>
+                <th className="border p-2">Adet</th>
+                <th className="border p-2">Birim Fiyat</th>
+                <th className="border p-2">Toplam</th>
+              </tr>
+            </thead>
+            <tbody>
+              {order.items.map((it) => (
+                <tr key={it.id}>
+                  <td className="border p-2">{it.description}</td>
+                  <td className="border p-2">{it.width}</td>
+                  <td className="border p-2">{it.height}</td>
+                  <td className="border p-2">{it.quantity}</td>
+                  <td className="border p-2">{it.unit_price}</td>
+                  <td className="border p-2">{it.total_price}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div>Yükleniyor...</div>
+      )}
+    </Layout>
+  );
+}

--- a/frontend/pages/orders/index.tsx
+++ b/frontend/pages/orders/index.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+import { listOrders, Order } from '../../lib/api/orders';
+
+export default function OrdersPage() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const token = '';
+  const org = '';
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await listOrders(token, org);
+      setOrders(data);
+    };
+    load();
+  }, []);
+
+  return (
+    <Layout>
+      <div className="flex mb-4">
+        <h1 className="text-xl font-bold flex-1">Siparişler</h1>
+        <Link href="/orders/new" className="bg-blue-500 text-white px-4 py-2">
+          Yeni Sipariş
+        </Link>
+      </div>
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr>
+            <th className="border p-2">No</th>
+            <th className="border p-2">Durum</th>
+            <th className="border p-2">Toplam</th>
+            <th className="border p-2">Detay</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((o) => (
+            <tr key={o.id}>
+              <td className="border p-2">{o.order_number}</td>
+              <td className="border p-2">{o.status}</td>
+              <td className="border p-2">{o.grand_total}</td>
+              <td className="border p-2">
+                <Link href={`/orders/${o.id}`} className="text-blue-500">
+                  Görüntüle
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Layout>
+  );
+}

--- a/frontend/pages/orders/new.tsx
+++ b/frontend/pages/orders/new.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Layout from '../../components/Layout';
+import { listPartners, Partner } from '../../lib/api/partners';
+import { listProducts, Product } from '../../lib/api/products';
+import { createOrder, OrderItemInput } from '../../lib/api/orders';
+
+export default function NewOrderPage() {
+  const [step, setStep] = useState(1);
+  const [partners, setPartners] = useState<Partner[]>([]);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [form, setForm] = useState<{ partner_id?: string; project_name?: string }>({});
+  const [items, setItems] = useState<OrderItemInput[]>([]);
+
+  const token = '';
+  const org = '';
+  const router = useRouter();
+
+  useEffect(() => {
+    const load = async () => {
+      const p = await listPartners(token, org);
+      const pr = await listProducts(token, org, {});
+      setPartners(p);
+      setProducts(pr);
+    };
+    load();
+  }, []);
+
+  const addItem = () => {
+    setItems([
+      ...items,
+      { product_id: '', width: 0, height: 0, quantity: 1, unit_price: 0 },
+    ]);
+  };
+
+  const updateItem = (index: number, field: keyof OrderItemInput, value: any) => {
+    const newItems = [...items];
+    // @ts-ignore
+    newItems[index][field] = value;
+    setItems(newItems);
+  };
+
+  const totalFor = (item: OrderItemInput) => {
+    return (
+      ((item.width || 0) / 1000) *
+      ((item.height || 0) / 1000) *
+      (item.quantity || 0) *
+      (item.unit_price || 0)
+    );
+  };
+
+  const grandTotal = items.reduce((sum, it) => sum + totalFor(it), 0);
+
+  const handleSubmit = async () => {
+    await createOrder(token, org, { ...form, items });
+    router.push('/orders');
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-xl font-bold mb-4">Yeni Sipariş</h1>
+      {step === 1 && (
+        <div className="space-y-4">
+          <div>
+            <label className="block mb-1">Partner</label>
+            <select
+              className="border p-2 w-full"
+              value={form.partner_id || ''}
+              onChange={(e) => setForm({ ...form, partner_id: e.target.value })}
+            >
+              <option value="">Seçiniz</option>
+              {partners.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block mb-1">Proje Adı</label>
+            <input
+              className="border p-2 w-full"
+              value={form.project_name || ''}
+              onChange={(e) => setForm({ ...form, project_name: e.target.value })}
+            />
+          </div>
+          <button
+            className="bg-blue-500 text-white px-4 py-2"
+            onClick={() => setStep(2)}
+          >
+            Devam
+          </button>
+        </div>
+      )}
+      {step === 2 && (
+        <div className="space-y-4">
+          <table className="min-w-full bg-white">
+            <thead>
+              <tr>
+                <th className="border p-2">Ürün</th>
+                <th className="border p-2">En (mm)</th>
+                <th className="border p-2">Boy (mm)</th>
+                <th className="border p-2">Adet</th>
+                <th className="border p-2">Birim Fiyat</th>
+                <th className="border p-2">Toplam</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, idx) => (
+                <tr key={idx}>
+                  <td className="border p-2">
+                    <select
+                      className="border p-1"
+                      value={item.product_id || ''}
+                      onChange={(e) => updateItem(idx, 'product_id', e.target.value)}
+                    >
+                      <option value="">Seçiniz</option>
+                      {products.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="border p-2">
+                    <input
+                      type="number"
+                      className="border p-1 w-24"
+                      value={item.width || 0}
+                      onChange={(e) => updateItem(idx, 'width', Number(e.target.value))}
+                    />
+                  </td>
+                  <td className="border p-2">
+                    <input
+                      type="number"
+                      className="border p-1 w-24"
+                      value={item.height || 0}
+                      onChange={(e) => updateItem(idx, 'height', Number(e.target.value))}
+                    />
+                  </td>
+                  <td className="border p-2">
+                    <input
+                      type="number"
+                      className="border p-1 w-20"
+                      value={item.quantity || 0}
+                      onChange={(e) => updateItem(idx, 'quantity', Number(e.target.value))}
+                    />
+                  </td>
+                  <td className="border p-2">
+                    <input
+                      type="number"
+                      className="border p-1 w-24"
+                      value={item.unit_price || 0}
+                      onChange={(e) => updateItem(idx, 'unit_price', Number(e.target.value))}
+                    />
+                  </td>
+                  <td className="border p-2">{totalFor(item).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <button
+            className="bg-green-500 text-white px-4 py-2"
+            onClick={addItem}
+          >
+            Satır Ekle
+          </button>
+          <div className="text-right font-bold">Genel Toplam: {grandTotal.toFixed(2)}</div>
+          <div className="flex space-x-2">
+            <button
+              className="bg-gray-300 px-4 py-2"
+              onClick={() => setStep(1)}
+            >
+              Geri
+            </button>
+            <button
+              className="bg-blue-500 text-white px-4 py-2"
+              onClick={handleSubmit}
+            >
+              Kaydet
+            </button>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add order service with sequential numbering, item totals, and production job creation on status change
- expose order endpoints including status update
- build frontend order management pages and navigation

## Testing
- `pytest`
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_68aec120d054832d885d72b0ae4fc347