### PR TITLE
Add finance module UI with transaction form

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -12,6 +12,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/categories">Categories</Link>
           <Link href="/orders">Siparişler</Link>
           <Link href="/production">Üretim Paneli</Link>
+          <Link href="/finance">Finans</Link>
         </nav>
       </aside>
       <div className="flex-1">

--- a/frontend/components/TransactionForm.tsx
+++ b/frontend/components/TransactionForm.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Account, TransactionInput, recordTransaction } from '../lib/api/finance';
+import { listPartners, Partner } from '../lib/api/partners';
+
+const schema = z.object({
+  account_id: z.string().min(1, 'Account is required'),
+  partner_id: z.string().optional(),
+  direction: z.enum(['IN', 'OUT']),
+  amount: z.coerce.number().positive(),
+  transaction_date: z.string().optional(),
+  description: z.string().optional(),
+  method: z.string().optional(),
+});
+
+export type TransactionFormValues = z.infer<typeof schema>;
+
+interface Props {
+  accounts: Account[];
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export default function TransactionForm({ accounts, onSuccess, onCancel }: Props) {
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<TransactionFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { direction: 'IN', transaction_date: new Date().toISOString().split('T')[0] },
+  });
+
+  const [partners, setPartners] = useState<Partner[]>([]);
+  const [partnerSearch, setPartnerSearch] = useState('');
+
+  const token = '';
+  const org = '';
+
+  useEffect(() => {
+    const loadPartners = async () => {
+      const data = await listPartners(token, org, partnerSearch ? { search: partnerSearch } : {});
+      setPartners(data);
+    };
+    loadPartners();
+  }, [partnerSearch]);
+
+  const onSubmit = async (data: TransactionFormValues) => {
+    await recordTransaction(token, org, data as TransactionInput);
+    reset();
+    onSuccess();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white p-6 rounded w-96 space-y-4">
+        <h2 className="text-lg font-bold">Yeni İşlem</h2>
+        <div>
+          <label className="block">Hesap</label>
+          <select className="border p-2 w-full" {...register('account_id')}>
+            <option value="">Seçiniz</option>
+            {accounts.map((a) => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
+          {errors.account_id && <p className="text-red-500 text-sm">{errors.account_id.message}</p>}
+        </div>
+        <div>
+          <label className="block">Partner</label>
+          <input
+            value={partnerSearch}
+            onChange={(e) => setPartnerSearch(e.target.value)}
+            placeholder="Ara"
+            className="border p-2 w-full mb-2"
+          />
+          <select className="border p-2 w-full" {...register('partner_id')}>
+            <option value="">Seçiniz</option>
+            {partners.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block">Yön</label>
+          <div className="flex space-x-4">
+            <label className="flex items-center space-x-1">
+              <input type="radio" value="IN" {...register('direction')} />
+              <span>Gelir</span>
+            </label>
+            <label className="flex items-center space-x-1">
+              <input type="radio" value="OUT" {...register('direction')} />
+              <span>Gider</span>
+            </label>
+          </div>
+        </div>
+        <div>
+          <label className="block">Tutar</label>
+          <input type="number" step="0.01" className="border p-2 w-full" {...register('amount', { valueAsNumber: true })} />
+          {errors.amount && <p className="text-red-500 text-sm">{errors.amount.message}</p>}
+        </div>
+        <div>
+          <label className="block">Tarih</label>
+          <input type="date" className="border p-2 w-full" {...register('transaction_date')} />
+        </div>
+        <div>
+          <label className="block">Açıklama</label>
+          <input className="border p-2 w-full" {...register('description')} />
+        </div>
+        <div>
+          <label className="block">Yöntem</label>
+          <input className="border p-2 w-full" {...register('method')} />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <button type="button" onClick={onCancel} className="px-4 py-2 bg-gray-300">Vazgeç</button>
+          <button type="submit" className="px-4 py-2 bg-blue-500 text-white">Kaydet</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+

--- a/frontend/lib/api/finance.ts
+++ b/frontend/lib/api/finance.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+});
+
+export interface Account {
+  id: string;
+  name: string;
+  type: string;
+  current_balance: number;
+}
+
+export interface TransactionInput {
+  account_id: string;
+  partner_id?: string;
+  direction: 'IN' | 'OUT';
+  amount: number;
+  transaction_date?: string;
+  description?: string;
+  method?: string;
+}
+
+export async function getAccounts(token: string, org: string) {
+  const res = await api.get<Account[]>(`/accounts`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}
+
+export async function recordTransaction(token: string, org: string, data: TransactionInput) {
+  const res = await api.post(`/financial_transactions`, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-Org-Slug': org,
+    },
+  });
+  return res.data;
+}

--- a/frontend/pages/finance/index.tsx
+++ b/frontend/pages/finance/index.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import TransactionForm from '../../components/TransactionForm';
+import { getAccounts, Account } from '../../lib/api/finance';
+
+export default function FinancePage() {
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const token = '';
+  const org = '';
+
+  const loadAccounts = async () => {
+    const data = await getAccounts(token, org);
+    setAccounts(data);
+  };
+
+  useEffect(() => {
+    loadAccounts();
+  }, []);
+
+  const handleSuccess = async () => {
+    setModalOpen(false);
+    await loadAccounts();
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-xl font-bold mb-4">Finans Yönetimi</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {accounts.map((a) => (
+          <div key={a.id} className="bg-white p-4 shadow">
+            <h2 className="text-lg font-semibold">{a.name}</h2>
+            <p className="text-gray-600">Bakiye: {a.current_balance}</p>
+          </div>
+        ))}
+      </div>
+      <button
+        onClick={() => setModalOpen(true)}
+        className="mt-4 bg-blue-500 text-white px-4 py-2"
+      >
+        Yeni İşlem Ekle
+      </button>
+      {modalOpen && (
+        <TransactionForm
+          accounts={accounts}
+          onSuccess={handleSuccess}
+          onCancel={() => setModalOpen(false)}
+        />
+      )}
+    </Layout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Finance API client for accounts and transactions
- create Finance page with account balances and add transaction button
- add reusable TransactionForm modal for recording new transactions
- link Finance in sidebar navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: next not found)

------
https://chatgpt.com/codex/tasks/task_e_68aec6e7ccac832da2cab84819b4a46e