### PR TITLE
Add Docker and compose setup for backend and frontend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.env
+ops/
+.git
+
+tests/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 ENV PYTHONPATH=/app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY app ./app
+COPY . .
+EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  postgres:
+    image: postgres:15
+    env_file:
+      - ops/.env
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build: ./backend
+    env_file:
+      - ops/.env
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/erp
+      - PYTHONPATH=/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8000
+    command: npm run dev
+
+volumes:
+  db-data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.git
+.gitignore
+Dockerfile
+.dockerignore
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- add Dockerfile for frontend and .dockerignore for both services
- refactor backend Dockerfile to copy project and expose port
- introduce root docker-compose.yml running postgres, backend and frontend

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed. Could not install due to 403 Forbidden)*
- `npm test` *(fails: Missing script "test" in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a5571158832d9858dfc50cfeedea