### PR TITLE
Fix backend service command in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./backend:/app
     networks:
       - infrastructure_net_backendservices
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8002 --reload
+    command: uvicorn backend.app.main:app --host 0.0.0.0 --port 8002 --reload
 
   s_dogus_erp_frontend:
     build: ./frontend


### PR DESCRIPTION
## Summary
- run backend with full module path from project root

## Testing
- `docker compose up --build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b4c9c214832d973e5a9847f16d09