### PR TITLE
fix: update frontend port configuration to 8002

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,14 +22,14 @@ services:
     container_name: c_dogus_erp_frontend
   
     ports:
-      - "8001:8001"
+      - "8002:8002"
     external_links:
     - s_dogus_erp_backend
     volumes:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - NEXT_PUBLIC_API_URL=http://s_dogus_erp_backend:8001
+      - NEXT_PUBLIC_API_URL=http://s_dogus_erp_backend:8002
     networks:
       - infrastructure_net_backendservices
     command: npm run dev

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
-EXPOSE 8001
+EXPOSE 8002
 CMD ["npm", "run", "dev"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "erp-frontend",
   "version": "1.0.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 8002",
     "build": "next build",
     "start": "next start"
   },


### PR DESCRIPTION
## Summary
- run frontend dev server on port 8002
- expose port 8002 in frontend Dockerfile
- configure docker-compose to use frontend port 8002 and point API URL to backend port 8002

## Testing
- `docker-compose up --build -d` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_68b57006a908832d80c7be515eac357b